### PR TITLE
Remove numbers from IMPLICIT_HYPHEN_KEYS

### DIFF
--- a/plover_portuguese.py
+++ b/plover_portuguese.py
@@ -9,7 +9,7 @@ KEYS = (
     '-R', '-W', '-B', '-P', '-G', '-H', '-T', '-S', '-D', '-Z',
 )
 
-IMPLICIT_HYPHEN_KEYS = ('A-', 'O-', '5-', '0-', '-E', '-U', '*')
+IMPLICIT_HYPHEN_KEYS = ('A-', 'O-', '-E', '-U', '*')
 
 SUFFIX_KEYS = ('-S', '-G', '-Z', '-D')
 


### PR DESCRIPTION
A user on the Plover Discord was having trouble using this plugin. This should fix it so it works on the current version of Plover.